### PR TITLE
Added support for multiple profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ This uses a browser source.
 - I recommend setting the width to 800 and height to 600 and leaving the next two options unticked.
 - Configure your setup by right-clicking on the overlay/source and clicking 'Interact'.
   
+If you want to setup multiple instances of the overlay with different layouts/settings you can add the `profile` parameter to the URL. `https://djcrqss.github.io/Woot-verlay/index.html?profile=p1` will be different from `https://djcrqss.github.io/Woot-verlay/index.html?profile=p2`. The `?profile=SOME_ID` will determine the profile and you can use any ID you want.
+
 If it doesn't work after some time, open this menu back up and click 'Refresh cache of current page'. 
 Note: customisations do not transfer across browsers or from browsers to OBS as they use their own local storage. You can go into presets and copy to clipboard, then paste it into your OBS in the same place.
 <br><br>

--- a/js/keyboard.js
+++ b/js/keyboard.js
@@ -12,6 +12,9 @@ class Key {
     }
 }
 
+// Get profile from URL
+var urlParams = new URLSearchParams(window.location.search);
+var profile = urlParams.get('profile');
 
 // Store list of keys and environment variables
 var keys = [];
@@ -58,9 +61,10 @@ function buildKey(curKey) {
 // get locally stored key states for usage
 function getState() {
     // localStorage.removeItem("keys");
-    if (localStorage.getItem("keys") != null) { // retrieve locally stored keys
-        var storedKeys = JSON.parse(localStorage.getItem("keys", storedKeys));
-        storedKeys.forEach(element => {
+    if (localStorage.getItem(`keys${profile && `-${profile}`}`) != null) {
+        // retrieve locally stored keys
+        var storedKeys = JSON.parse(localStorage.getItem(`keys${profile && `-${profile}`}`, storedKeys));
+        storedKeys.forEach((element) => {
             keys.push(new Key(element[0], element[1], element[2], element[3], element[4], element[5], element[6]));
         });
 
@@ -120,7 +124,7 @@ function saveState() {
 
     }
     // store updated keys in local storage
-    localStorage.setItem("keys", JSON.stringify(storedKeys));
+    localStorage.setItem(`keys${profile && `-${profile}`}`, JSON.stringify(storedKeys));
     buildOptions();
 }
 

--- a/js/keypool.js
+++ b/js/keypool.js
@@ -1,3 +1,7 @@
+// Get profile from URL
+var urlParams = new URLSearchParams(window.location.search);
+var profile = urlParams.get('profile');
+
 // convert key ID's to readable names
 const keyPairs = {
     A: 4, B: 5, C: 6, D: 7, E: 8, F: 9, G: 10, H: 11, I: 12, J: 13, K: 14, L: 15, M: 16, N: 17, O: 18, P: 19, Q: 20, R: 21, S: 22, T: 23, U: 24, V: 25, W: 26, X: 27, Y: 28, Z: 29,
@@ -37,5 +41,5 @@ function buildOptions() {
         }
     }
 
-    presetInput.value = localStorage.getItem("keys");
+    presetInput.value = localStorage.getItem(`keys${profile && `-${profile}`}`);
 }

--- a/js/toolbarfunctions.js
+++ b/js/toolbarfunctions.js
@@ -1,3 +1,7 @@
+// Get profile from URL
+var urlParams = new URLSearchParams(window.location.search);
+var profile = urlParams.get('profile');
+
 // related to all the differnt menus and their functions in the toolbar
 
 const activeColPicker = document.getElementById('activeColorPicker');
@@ -12,14 +16,14 @@ const transitionCheckbox = document.getElementById('transitionCheckbox');
 
 // COLOURS
 var colours;
-// get colours from storage
-if (localStorage.getItem("colours")) {
+// get colours from storage;
+if (localStorage.getItem(`colours${profile && `-${profile}`}`)) {
     colours = new Array(
-        JSON.parse(localStorage.getItem("colours"))[0],
-        JSON.parse(localStorage.getItem("colours"))[1],
-        JSON.parse(localStorage.getItem("colours"))[2],
-        JSON.parse(localStorage.getItem("colours"))[3],
-        JSON.parse(localStorage.getItem("colours"))[4]
+        JSON.parse(localStorage.getItem(`colours${profile && `-${profile}`}`))[0],
+        JSON.parse(localStorage.getItem(`colours${profile && `-${profile}`}`))[1],
+        JSON.parse(localStorage.getItem(`colours${profile && `-${profile}`}`))[2],
+        JSON.parse(localStorage.getItem(`colours${profile && `-${profile}`}`))[3],
+        JSON.parse(localStorage.getItem(`colours${profile && `-${profile}`}`))[4]
     );
     // set colours on screen
     document.documentElement.style.setProperty('--active', colours[0]);
@@ -99,7 +103,7 @@ function updateColours() {
     document.documentElement.style.setProperty('--prim-color', colours[2]);
     document.documentElement.style.setProperty('--key-color', colours[3]);
     document.documentElement.style.setProperty('--app-bg', colours[4]);
-    localStorage.setItem("colours", JSON.stringify(colours));
+    localStorage.setItem(`colours${profile && `-${profile}`}`, JSON.stringify(colours));
 }
 
 
@@ -139,10 +143,10 @@ inputCheckbox.addEventListener('change', function () {
 
 
 // rounding
-var isRounded = JSON.parse(localStorage.getItem("isRounded")) || false;
+var isRounded = JSON.parse(localStorage.getItem(`isRounded${profile && `-${profile}`}`)) || false;
 document.getElementById("roundingCheckbox").onclick = function () {
     isRounded = this.checked;
-    localStorage.setItem("isRounded", this.checked);
+    localStorage.setItem(`isRounded${profile && `-${profile}`}}`, this.checked);
 };
 document.getElementById("roundingCheckbox").checked = isRounded;
 
@@ -165,7 +169,7 @@ async function pasteFromClipboard() {
 
 // custom presets 
 for (let i = 0; i < 3; i++) {
-    let presetName = localStorage.getItem("preset" + i + "Name");
+    let presetName = localStorage.getItem(`preset${profile && `-${profile}`}` + i + "Name");
     if (presetName != null) {
         document.getElementById("preset" + i + "Name").innerHTML = presetName;
     }
@@ -173,11 +177,11 @@ for (let i = 0; i < 3; i++) {
 
 function loadPreset(presetNum) {
     // load from localstorage
-    let preset = localStorage.getItem("preset" + presetNum);
+    let preset = localStorage.getItem(`preset${profile && `-${profile}`}` + presetNum);
     if (preset != null) {
         loadState(preset);
-        if(localStorage.getItem("preset" + presetNum + "Colours") != null) {
-            colours = JSON.parse(localStorage.getItem("preset" + presetNum + "Colours"));
+        if(localStorage.getItem(`preset${profile && `-${profile}`}` + presetNum + "Colours") != null) {
+            colours = JSON.parse(localStorage.getItem(`preset${profile && `-${profile}`}` + presetNum + "Colours"));
             updateColours();
             updateColourPickers();
         }
@@ -189,7 +193,7 @@ function loadPreset(presetNum) {
 
 function savePreset(presetNum) {
     // save to localstorage
-    if (localStorage.getItem("preset" + presetNum) != null) {
+    if (localStorage.getItem(`preset${profile && `-${profile}`}` + presetNum) != null) {
         if (!confirm("There is already a preset saved in this slot. Do you want to overwrite it?")) {
             return;
         }
@@ -202,9 +206,9 @@ function savePreset(presetNum) {
     }
     // set name on screen
     document.getElementById("preset" + presetNum + "Name").innerHTML = presetName;
-    localStorage.setItem("preset" + presetNum, localStorage.getItem("keys"));
-    localStorage.setItem("preset" + presetNum + "Colours", JSON.stringify(colours));
-    localStorage.setItem("preset" + presetNum + "Name", presetName);
+    localStorage.setItem(`preset${profile && `-${profile}`}` + presetNum, localStorage.getItem(`keys${profile && `-${profile}`}`));
+    localStorage.setItem(`preset${profile && `-${profile}`}` + presetNum + "Colours", JSON.stringify(colours));
+    localStorage.setItem(`preset${profile && `-${profile}`}` + presetNum + "Name", presetName);
 }
 
 // default presets


### PR DESCRIPTION
I play many different games and need to use different layouts for each of them on stream. I don't want to to manually edit layouts by going into each browser source every time.

I'm sure other people may have had a similar experience so I made this pull request.

It's really simple. Just adding `?profile=SOME_ID` to the end of the URL will treat the new browser source as a unique instance with its own settings and layout.